### PR TITLE
fix memory leak warning on ipcPromise.emit

### DIFF
--- a/test/no-memory-warning/index.html
+++ b/test/no-memory-warning/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script charset="utf-8" src="../../ipc-promise.js"></script>
+<script>
+  const remote = require('electron').remote;
+
+  const calls = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+  const sequentialPromise = calls.reduce(function (prevPromise, count) {
+    return prevPromise.then(function(){
+      return ipcPromise
+        .send('message', {
+          count: count
+        });
+    });
+  }, Promise.resolve());
+  sequentialPromise.then(function () {
+    return ipcPromise.send('check-memory-status');
+  }).then(function (status) {
+    if (status === 'ok') {
+      remote.app.exit(0);
+    } else {
+      remote.app.exit(1);
+    }
+  }).catch(function () {
+    remote.app.exit(1);
+  });
+</script>

--- a/test/no-memory-warning/index.js
+++ b/test/no-memory-warning/index.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// NOTE: return test title when required by mocha
+if (typeof require('electron') === 'string') {
+  return (module.exports = 'can pass params to main process');
+}
+
+const path = require('path'),
+  url = require('url');
+
+const electron = require('electron'),
+  app = electron.app,
+  BrowserWindow = electron.BrowserWindow;
+
+const ipcPromise = require('../../ipc-promise');
+
+let mainWindow;
+
+let isCalledMemoryWarning = false;
+process.on('warning', function (warning) {
+  isCalledMemoryWarning = true;
+  console.log(warning);
+});
+
+
+ipcPromise.on('message', function (params, event) {
+  if (typeof params === 'object' && typeof event === 'object') {
+    return Promise.resolve({
+      value: params.value * 2,
+    });
+  } else {
+    return Promise.reject(
+      new TypeError('invalid types')
+    );
+  }
+});
+ipcPromise.on('check-memory-status', function () {
+  if (!isCalledMemoryWarning) {
+    return Promise.resolve("ok");
+  }else{
+    return Promise.reject(new Error("ng"));
+  }
+});
+
+app.on('ready', function () {
+  mainWindow = new BrowserWindow({
+    show: false,
+  });
+
+  mainWindow.on('closed', function () {
+    mainWindow = null;
+  });
+
+  const index = url.format({
+    protocol: 'file',
+    slashes: true,
+    pathname: path.join(__dirname, 'index.html'),
+  });
+
+  mainWindow.loadURL(index);
+});


### PR DESCRIPTION
When call 11-times `ipcPromise.send`, show EventEmitter memory warning.
This PR fix it.